### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,10 +12,10 @@ PCF8591	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-begin KEYWORD2
-AnalogInput KEYWORD2
-analogRead KEYWORD2
-analogWrite KEYWORD2
+begin	KEYWORD2
+AnalogInput	KEYWORD2
+analogRead	KEYWORD2
+analogWrite	KEYWORD2
 
-voltageWrite KEYWORD2
-voltageRead KEYWORD2
+voltageWrite	KEYWORD2
+voltageRead	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords